### PR TITLE
SDAP-132 Update ningesterpy to select random port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+current_port
 
 ### Python template
 # Byte-compiled / optimized / DLL files

--- a/.idea/ningesterpy.iml
+++ b/.idea/ningesterpy.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.5.4 (~/anaconda/envs/ningesterpy/bin/python)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-werkzeug==0.12.2
-flask==0.12.2
-flask-accept==0.0.4
+werkzeug==0.14.1
+flask==1.0.2
+flask-accept==0.0.6
 nexusproto===1.0.0-SNAPSHOT
 numpy==1.12.1
 protobuf==3.2.0

--- a/sdap/default_settings.py
+++ b/sdap/default_settings.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SERVER_NAME = '127.0.0.1:5000'
+PORT_FILE = 'current_port'
+CREATE_PORT_FILE = False

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SERVER_NAME = '127.0.0.1:0'
+ENV = 'development'
+PORT_FILE = 'current_port'
+CREATE_PORT_FILE = True


### PR DESCRIPTION
Make the host and port configurable and enable the use of a random port.

The expected use case of this application is to be within the [ningester](https://github.com/apache/incubator-sdap-ningester/tree/master/docker) docker container running as a process next to the `ningester` Java process. Normally, we don't need to worry about port conflicts within a docker container.

However, a problem was noticed when deploying this to AWS Batch. Namely that AWS Batch runs containers in `network=host` mode instead of using a bridge network. This causes port conflicts when AWS tries to run multiple instances of the ningester container on the same host (because every instance is trying to bind to port 5000 of the host).

The solution in this PR is to allow ningesterpy to select a random available port to bind to during startup so that multiple instances of the ningester container can run on the same host at the same time when using host networking.

This is related to PR https://github.com/apache/incubator-sdap-ningester/pull/11